### PR TITLE
新增難度選擇、色盲模式和隨機顏色/Grid佈局

### DIFF
--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -12,10 +12,18 @@ interface GameData {
 const GamePage: React.FC = () => {
     const location = useLocation();
     const initialData = location.state as { game_id: number };
+    const difficulty = location.state?.difficulty || 9;
+    const colorBlindMode = location.state?.colorBlindMode || false;
 
     const [blocks, setBlocks] = useState<number[]>([]);
     const [clickedIds, setClickedIds] = useState<number[]>([]);
     const [gameId, setGameId] = useState<number | null>(null);
+    const [hue, setHue] = useState<number>(Math.floor(Math.random() * 360));
+
+    const count = blocks.length;
+    const cols  = count > 0 ? Math.ceil(Math.sqrt(count)) : 1;
+    const rows  = count > 0 ? Math.ceil(count / cols) : 1;
+
 
     // 初始設定
     useEffect(() => {
@@ -44,6 +52,7 @@ const GamePage: React.FC = () => {
                 }
 
                 const questionData = data as GameData;
+                setHue(Math.floor(Math.random() * 360));
                 setBlocks(questionData.blocks);
                 setQuestionNumber(questionData.question_number);
                 setTotalQuestions(questionData.total_questions);
@@ -86,23 +95,59 @@ const GamePage: React.FC = () => {
             {!isFinished ? (
                 <>
                     <h2>第 {questionNumber} / {totalQuestions} 題：請依序點擊色塊</h2>
-                    <div style={{ display: 'flex', flexWrap: 'wrap', maxWidth: '300px', margin: 'auto' }}>
-                        {blocks.map((id, index) => (
+                    {/* 以 grid 方式排列，依照 cols × rows 動態設定 */}
+                    <div
+                    style={{
+                        display: 'grid',
+                        gridTemplateColumns: `repeat(${cols}, 90px)`,
+                        gridTemplateRows: `repeat(${rows}, 90px)`,
+                        gap: '10px',
+                        justifyContent: 'center',
+                        margin: 'auto'
+                    }}
+                    >
+                    {blocks.map((_, index) => {
+                        const t = index / (blocks.length - 1);
+
+                        if (colorBlindMode) {
+                        // 色盲模式：固定藍色系，依序用亮度漸層
+                        const hueCB = 240;
+                        const lightness = 30 + t * 50;  // 30% → 80%
+                        return (
                             <div
-                                key={index}
-                                onClick={() => handleClick(id)}
-                                style={{
-                                    width: '90px',
-                                    height: '90px',
-                                    boxSizing: 'border-box',
-                                    backgroundColor: `hsl(210, 80%, ${30 + (id / blocks.length) * 50}%)`,
-                                    margin: '5px',
-                                    cursor: 'pointer',
-                                    border: clickedIds.includes(id) ? '4px solid black' : 'none',
-                                }}
-                            ></div>
-                        ))}
+                            key={index}
+                            onClick={() => handleClick(blocks[index])}
+                            style={{
+                                width: '90px',
+                                height: '90px',
+                                boxSizing: 'border-box',
+                                backgroundColor: `hsl(${hueCB}, 80%, ${lightness}%)`,
+                                cursor: 'pointer',
+                                border: clickedIds.includes(blocks[index]) ? '4px solid black' : 'none',
+                            }}
+                            />
+                        );
+                        } else {
+                        // 一般模式：隨機 hue，依序用更大亮度範圍漸層
+                        const lightness = 20 + t * 60;  // 20% → 80%
+                        return (
+                            <div
+                            key={index}
+                            onClick={() => handleClick(blocks[index])}
+                            style={{
+                                width: '90px',
+                                height: '90px',
+                                boxSizing: 'border-box',
+                                backgroundColor: `hsl(${hue}, 80%, ${lightness}%)`,
+                                cursor: 'pointer',
+                                border: clickedIds.includes(blocks[index]) ? '4px solid black' : 'none',
+                            }}
+                            />
+                        );
+                        }
+                    })}
                     </div>
+
                     {!isSubmitted ? (
                         <button onClick={handleSubmit} disabled={clickedIds.length === 0} style={{ marginTop: '20px' }}>
                             提交答案

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,23 +1,61 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const HomePage: React.FC = () => {
+    const [difficulty, setDifficulty] = useState(9);
+    const [colorBlindMode, setColorBlindMode] = useState(false);
     const navigate = useNavigate();
 
     const handleStartGame = async () => {
         const res = await fetch('http://localhost:8000/start_game', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ count: 3, mode: 'normal', total_questions: 5 }),
+            body: JSON.stringify({
+                count: difficulty,                          // ✅ 改這裡
+                mode: colorBlindMode ? 'colorblind' : 'normal',       // ✅ 改這裡
+                total_questions: 5
+            }),
         });
         const data = await res.json();
-        navigate('/game', { state: { game_id: data.game_id } });  // ✅ 只傳 game_id
+        navigate('/game', {
+            state: {
+                game_id: data.game_id,
+                difficulty,
+                colorBlindMode
+            }
+        });
     };
 
     return (
         <div style={{ textAlign: 'center', paddingTop: '50px' }}>
             <h1>Color Sort 遊戲首頁</h1>
-            <button onClick={handleStartGame}>開始遊戲</button>
+
+            <div>
+                <label>Choose Difficulty:</label>
+                <select value={difficulty} onChange={(e) => setDifficulty(Number(e.target.value))}>
+                    <option value={6}>6 tiles</option>
+                    <option value={9}>9 tiles</option>
+                    <option value={12}>12 tiles</option>
+                    <option value={16}>16 tiles</option>
+                    <option value={20}>20 tiles</option>
+                    <option value={25}>25 tiles</option>
+                </select>
+            </div>
+
+            <div>
+                <label>
+                    <input
+                        type="checkbox"
+                        checked={colorBlindMode}
+                        onChange={(e) => setColorBlindMode(e.target.checked)}
+                    />
+                    Color Blind Mode
+                </label>
+            </div>
+
+            <button onClick={handleStartGame}>
+                Start Game
+            </button>
         </div>
     );
 };


### PR DESCRIPTION
- 在 HomePage 新增「難度選擇」下拉選單與「色盲模式」切換  
- 將 Start Game 按鈕改為呼叫 /start_game API，並傳遞 difficulty 與 colorBlindMode  
- 在 GamePage 使用 CSS Grid 動態排列色塊（cols × rows）  
- 支援隨機色相漸層與色盲友善藍色＋亮度漸層顯示  
